### PR TITLE
CMake fix on examples

### DIFF
--- a/examples/contact/CMakeLists.txt
+++ b/examples/contact/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-if(TRIBOL_FOUND AND STRUMPACK_FOUND)
+if(TRIBOL_FOUND AND STRUMPACK_DIR)
     set(CONTACT_EXAMPLES_SOURCES
         beam_bending.cpp
         ironing.cpp

--- a/examples/contact/homotopy/CMakeLists.txt
+++ b/examples/contact/homotopy/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-if (TRIBOL_FOUND AND STRUMPACK_FOUND AND SMITH_ENABLE_CONTINUATION)
+if (TRIBOL_FOUND AND STRUMPACK_DIR AND SMITH_ENABLE_CONTINUATION)
     smith_add_executable(NAME       two_blocks_example
                          SOURCES    two_blocks.cpp
                          OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}

--- a/examples/inertia_relief/CMakeLists.txt
+++ b/examples/inertia_relief/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-if (SMITH_ENABLE_CONTINUATION AND STRUMPACK_FOUND)
+if (SMITH_ENABLE_CONTINUATION AND STRUMPACK_DIR)
     smith_add_executable( NAME        inertia_relief_example
                           SOURCES     inertia_relief_example.cpp
                           OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}

--- a/examples/obstacle_design/CMakeLists.txt
+++ b/examples/obstacle_design/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-if (SMITH_ENABLE_CONTINUATION AND STRUMPACK_FOUND)
+if (SMITH_ENABLE_CONTINUATION AND STRUMPACK_DIR)
     smith_add_executable( NAME        obstacle_design_example
                           SOURCES     obstacle_design_example.cpp
                           OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}

--- a/examples/uniaxial/CMakeLists.txt
+++ b/examples/uniaxial/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-if (STRUMPACK_FOUND)
+if (STRUMPACK_DIR)
     smith_add_executable( NAME        uniaxial_tension
                           SOURCES     uniaxial_tension.cpp
                           OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}


### PR DESCRIPTION
In a previous PR #1621 I erroneously changed `STRUMPACK_DIR` to `STRUMPACK_FOUND` in various CMake files associated to the examples. I am now reverting back to using `STRUMPACK_DIR`. Upon looking closer at `SetupSmithThirdParty.cmake` it appears that since strumpack will come via mfem, if it is made available at all, then smith doesn't set/use/define `STRUMPACK_FOUND` rather all the logic is done via `STRUMPACK_DIR`.